### PR TITLE
Fix scatter_add bug in SETLayer.forward

### DIFF
--- a/synapses/SET_layer.py
+++ b/synapses/SET_layer.py
@@ -258,5 +258,5 @@ class SETLayer(nn.Module):
     def forward(self, x):
         k = x[:, self.inds]
         k = k * self.weight
-        z = scatter_add(k, self.inds_out)
+        z = scatter_add(k, self.inds_out, dim_size=self.outdim)
         return z + self.bias


### PR DESCRIPTION
A bug in scatter_add could cause a dimension mismatch in the `return z + self.bias`  line of `SETLayer.forward`. The call `scatter_add(k, self.inds_out)` produces a tensor of length `max(self.inds_out)+1`, which might not be equal to `self.outdim`. This commit fixes this issue by using the `dim_size` keyword of the `scatter_add` function.